### PR TITLE
Feature/rabbitmq-config

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -3,12 +3,16 @@ load('ext://restart_process', 'docker_build_with_restart')
 
 ### K8s Config ###
 
-# Uncomment to use secrets
-# k8s_yaml('./infra/development/k8s/secrets.yaml')
-
+k8s_yaml('./infra/development/k8s/secrets.yaml')
 k8s_yaml('./infra/development/k8s/app-config.yaml')
 
 ### End of K8s Config ###
+### RabbitMQ ###
+
+k8s_yaml('./infra/development/k8s/rabbitmq-deployment.yaml')
+k8s_resource('rabbitmq', port_forwards=['5672', '15672'], labels='tooling')
+
+### End RabbitMQ ###
 ### API Gateway ###
 
 gateway_compile_cmd = 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/api-gateway ./services/api-gateway'

--- a/Tiltfile
+++ b/Tiltfile
@@ -42,7 +42,7 @@ docker_build_with_restart(
 
 k8s_yaml('./infra/development/k8s/api-gateway-deployment.yaml')
 k8s_resource('api-gateway', port_forwards=8081,
-             resource_deps=['api-gateway-compile'], labels="services")
+             resource_deps=['api-gateway-compile', 'rabbitmq'], labels="services")
              
 ### End of API Gateway ###
 ### Trip Service ###
@@ -72,7 +72,7 @@ docker_build_with_restart(
 )
 
 k8s_yaml('./infra/development/k8s/trip-service-deployment.yaml')
-k8s_resource('trip-service', resource_deps=['trip-service-compile'], labels="services")
+k8s_resource('trip-service', resource_deps=['trip-service-compile', 'rabbitmq'], labels="services")
 
 ### End of Trip Service ###
 ### Driver Service ###
@@ -102,7 +102,7 @@ docker_build_with_restart(
 )
 
 k8s_yaml('./infra/development/k8s/driver-service-deployment.yaml')
-k8s_resource('driver-service', resource_deps=['driver-service-compile'], labels="services")
+k8s_resource('driver-service', resource_deps=['driver-service-compile', 'rabbitmq'], labels="services")
 
 ### End of Driver Service ###
 ### Web Frontend ###

--- a/infra/development/k8s/driver-service-deployment.yaml
+++ b/infra/development/k8s/driver-service-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: driver-service
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: driver-service

--- a/infra/development/k8s/driver-service-deployment.yaml
+++ b/infra/development/k8s/driver-service-deployment.yaml
@@ -24,6 +24,13 @@ spec:
             limits:
               memory: "128Mi"
               cpu: "125m"
+          env:
+            - name: RABBITMQ_URI
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: uri
+
 ---
 apiVersion: v1
 kind: Service

--- a/infra/development/k8s/rabbitmq-deployment.yaml
+++ b/infra/development/k8s/rabbitmq-deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: rabbitmq
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: rabbitmq
@@ -17,6 +18,19 @@ spec:
           ports:
             - containerPort: 5672
             - containerPort: 15672
+          readinessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "check_running"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 15
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "check_running"]
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 15
           resources:
             requests:
               memory: "512Mi"

--- a/infra/development/k8s/rabbitmq-deployment.yaml
+++ b/infra/development/k8s/rabbitmq-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+spec:
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3-management
+          ports:
+            - containerPort: 5672
+            - containerPort: 15672
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: username
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: password
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+spec:
+  selector:
+    app: rabbitmq
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: 5672
+    - name: management
+      port: 15672
+      targetPort: 15672
+  type: ClusterIP

--- a/infra/development/k8s/rabbitmq-deployment.yaml
+++ b/infra/development/k8s/rabbitmq-deployment.yaml
@@ -1,8 +1,9 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: rabbitmq
 spec:
+  serviceName: "rabbitmq"
   replicas: 1
   selector:
     matchLabels:
@@ -49,6 +50,19 @@ spec:
                 secretKeyRef:
                   name: rabbitmq-credentials
                   key: password
+            - name: RABBITMQ_MNESIA_BASE
+              value: /var/lib/rabbitmq/mnesia
+          volumeMounts:
+            - name: rabbitmq-data
+              mountPath: /var/lib/rabbitmq
+  volumeClaimTemplates:
+    - metadata:
+        name: rabbitmq-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
 
 ---
 apiVersion: v1

--- a/infra/development/k8s/rabbitmq-deployment.yaml
+++ b/infra/development/k8s/rabbitmq-deployment.yaml
@@ -24,14 +24,14 @@ spec:
               command: ["rabbitmq-diagnostics", "check_running"]
             initialDelaySeconds: 60
             periodSeconds: 30
-            timeoutSeconds: 15
+            timeoutSeconds: 20
             failureThreshold: 3
           livenessProbe:
             exec:
               command: ["rabbitmq-diagnostics", "check_running"]
             initialDelaySeconds: 60
             periodSeconds: 30
-            timeoutSeconds: 15
+            timeoutSeconds: 20
           resources:
             requests:
               memory: "512Mi"

--- a/infra/development/k8s/trip-service-deployment.yaml
+++ b/infra/development/k8s/trip-service-deployment.yaml
@@ -24,6 +24,12 @@ spec:
             limits:
               memory: "128Mi"
               cpu: "200m"
+          env:
+            - name: RABBITMQ_URI
+              valueFrom:
+                secretKeyRef:
+                  name: rabbitmq-credentials
+                  key: uri
 ---
 apiVersion: v1
 kind: Service

--- a/services/api-gateway/http.go
+++ b/services/api-gateway/http.go
@@ -25,8 +25,8 @@ func handleTripStart(w http.ResponseWriter, r *http.Request) {
 	trip, err := tripService.Client.CreateTrip(r.Context(), reqBody.toProto())
 
 	if err != nil {
-		log.Printf("Failed to preview a trip: %v", err)
-		http.Error(w, "failed to preview trip", http.StatusInternalServerError)
+		log.Printf("Failed to start a trip: %v", err)
+		http.Error(w, "failed to start trip", http.StatusInternalServerError)
 		return
 	}
 

--- a/services/driver-service/main.go
+++ b/services/driver-service/main.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"ride-sharing/shared/env"
+	"ride-sharing/shared/messaging"
 	"syscall"
 
 	grpcserver "google.golang.org/grpc"
@@ -14,6 +16,8 @@ import (
 var GrpcAddr = ":9092"
 
 func main() {
+	rabbitmqUri := env.GetString("RABBITMQ_URI", "amqp://guest:guest@rabbitmq:5672/")
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -30,6 +34,12 @@ func main() {
 	}
 
 	service := NewService()
+
+	rabbitmq, err := messaging.NewRabbitMQ(rabbitmqUri)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rabbitmq.Close()
 
 	grcpServer := grpcserver.NewServer()
 	NewGrpcHandler(grcpServer, service)

--- a/services/driver-service/main.go
+++ b/services/driver-service/main.go
@@ -44,7 +44,7 @@ func main() {
 	grcpServer := grpcserver.NewServer()
 	NewGrpcHandler(grcpServer, service)
 
-	consumer := NewTripEventConsumer(rabbitmq)
+	consumer := NewTripEventConsumer(rabbitmq, service)
 	go func() {
 		if err := consumer.Listen(); err != nil {
 			log.Fatalf("failed to listen to the message: %v", err)

--- a/services/driver-service/main.go
+++ b/services/driver-service/main.go
@@ -44,6 +44,13 @@ func main() {
 	grcpServer := grpcserver.NewServer()
 	NewGrpcHandler(grcpServer, service)
 
+	consumer := NewTripEventConsumer(rabbitmq)
+	go func() {
+		if err := consumer.Listen(); err != nil {
+			log.Fatalf("failed to listen to the message: %v", err)
+		}
+	}()
+
 	log.Printf("Starting gRPC server Driver service on port %s", lis.Addr().String())
 
 	go func() {

--- a/services/driver-service/service.go
+++ b/services/driver-service/service.go
@@ -24,6 +24,22 @@ func NewService() *Service {
 	}
 }
 
+func (s *Service) FindAvailableDrivers(packageType string) []string {
+	var matchingDrivers []string
+
+	for _, driver := range s.drivers {
+		if driver.Driver.PackageSlug == packageType {
+			matchingDrivers = append(matchingDrivers, driver.Driver.Id)
+		}
+	}
+
+	if len(matchingDrivers) == 0 {
+		return []string{}
+	}
+
+	return matchingDrivers
+}
+
 func (s *Service) RegisterDriver(driverId string, packageSlug string) (*pb.Driver, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/services/driver-service/trip_consumer.go
+++ b/services/driver-service/trip_consumer.go
@@ -64,7 +64,8 @@ func (c *tripEventConsumer) handleFindAndNotifyDrivers(ctx context.Context, payl
 	suitableDriverID := suitableIDs[0]
 	marshalledEvent, err := json.Marshal(suitableDriverID)
 	if err != nil {
-		return nil
+		log.Printf("Failed to marshal suitableDriverID: %v", err)
+		return err
 	}
 
 	if err := c.rabbitmq.PublishMessage(ctx, contracts.DriverCmdTripRequest, contracts.AmqpMessage{

--- a/services/driver-service/trip_consumer.go
+++ b/services/driver-service/trip_consumer.go
@@ -2,27 +2,77 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log"
+	"ride-sharing/shared/contracts"
 	"ride-sharing/shared/messaging"
-	"time"
 
 	"github.com/rabbitmq/amqp091-go"
 )
 
 type tripEventConsumer struct {
 	rabbitmq *messaging.RabbitMQ
+	service  *Service
 }
 
-func NewTripEventConsumer(rabbitmq *messaging.RabbitMQ) *tripEventConsumer {
+func NewTripEventConsumer(rabbitmq *messaging.RabbitMQ, service *Service) *tripEventConsumer {
 	return &tripEventConsumer{
 		rabbitmq: rabbitmq,
+		service:  service,
 	}
 }
 
 func (c *tripEventConsumer) Listen() error {
-	return c.rabbitmq.ConsumeMessage("hello", func(ctx context.Context, msg amqp091.Delivery) error {
-		log.Printf("driver received message: %v", msg)
-		time.Sleep(time.Second * 15)
+	return c.rabbitmq.ConsumeMessage(messaging.FindAvailableDriversQueue, func(ctx context.Context, msg amqp091.Delivery) error {
+		var tripEvent contracts.AmqpMessage
+		if err := json.Unmarshal(msg.Body, &tripEvent); err != nil {
+			log.Printf("Failed to unmarshal message: %v", err)
+			return err
+		}
+
+		var payload messaging.TripEventData
+		if err := json.Unmarshal(tripEvent.Data, &payload); err != nil {
+			return err
+		}
+
+		switch msg.RoutingKey {
+		case contracts.TripEventCreated, contracts.TripEventDriverNotInterested:
+			return c.handleFindAndNotifyDrivers(ctx, payload)
+		}
+
+		log.Printf("unknown trip event: %+v", payload)
+
 		return nil
 	})
+}
+
+func (c *tripEventConsumer) handleFindAndNotifyDrivers(ctx context.Context, payload messaging.TripEventData) error {
+	suitableIDs := c.service.FindAvailableDrivers(payload.Trip.SelectedFare.PackageSlug)
+
+	log.Printf("Found suitable drivers %v", len(suitableIDs))
+
+	if len(suitableIDs) == 0 {
+		if err := c.rabbitmq.PublishMessage(ctx, contracts.TripEventNoDriversFound, contracts.AmqpMessage{
+			OwnerID: payload.Trip.UserID,
+		}); err != nil {
+			log.Printf("Failed to publish message to exchange: %v", err)
+		}
+
+		return nil
+	}
+
+	suitableDriverID := suitableIDs[0]
+	marshalledEvent, err := json.Marshal(suitableDriverID)
+	if err != nil {
+		return nil
+	}
+
+	if err := c.rabbitmq.PublishMessage(ctx, contracts.DriverCmdTripRequest, contracts.AmqpMessage{
+		OwnerID: payload.Trip.UserID,
+		Data:    marshalledEvent,
+	}); err != nil {
+		log.Printf("Failed to publish message to exchange: %v", err)
+	}
+
+	return nil
 }

--- a/services/driver-service/trip_consumer.go
+++ b/services/driver-service/trip_consumer.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"log"
+	"ride-sharing/shared/messaging"
+	"time"
+
+	"github.com/rabbitmq/amqp091-go"
+)
+
+type tripEventConsumer struct {
+	rabbitmq *messaging.RabbitMQ
+}
+
+func NewTripEventConsumer(rabbitmq *messaging.RabbitMQ) *tripEventConsumer {
+	return &tripEventConsumer{
+		rabbitmq: rabbitmq,
+	}
+}
+
+func (c *tripEventConsumer) Listen() error {
+	return c.rabbitmq.ConsumeMessage("hello", func(ctx context.Context, msg amqp091.Delivery) error {
+		log.Printf("driver received message: %v", msg)
+		time.Sleep(time.Second * 15)
+		return nil
+	})
+}

--- a/services/trip-service/cmd/main.go
+++ b/services/trip-service/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"ride-sharing/services/trip-service/internal/infrastructure/events"
 	"ride-sharing/services/trip-service/internal/infrastructure/grpc"
 	"ride-sharing/services/trip-service/internal/infrastructure/repository"
 	"ride-sharing/services/trip-service/internal/service"
@@ -45,9 +46,11 @@ func main() {
 	}
 	defer rabbitmq.Close()
 
+	publisher := events.NewTripEventPublisher(rabbitmq)
+
 	grcpServer := grpcserver.NewServer()
 
-	grpc.NewGrpcHandler(grcpServer, svc)
+	grpc.NewGrpcHandler(grcpServer, svc, publisher)
 
 	log.Printf("Starting gRPC server Trip service on port %s", lis.Addr().String())
 

--- a/services/trip-service/cmd/main.go
+++ b/services/trip-service/cmd/main.go
@@ -9,6 +9,8 @@ import (
 	"ride-sharing/services/trip-service/internal/infrastructure/grpc"
 	"ride-sharing/services/trip-service/internal/infrastructure/repository"
 	"ride-sharing/services/trip-service/internal/service"
+	"ride-sharing/shared/env"
+	"ride-sharing/shared/messaging"
 	"syscall"
 
 	grpcserver "google.golang.org/grpc"
@@ -17,6 +19,8 @@ import (
 var GrpcAddr = ":9093"
 
 func main() {
+	rabbitmqUri := env.GetString("RABBITMQ_URI", "amqp://guest:guest@rabbitmq:5672/")
+
 	inmemRepo := repository.NewInmemRepository()
 	svc := service.NewService(inmemRepo)
 
@@ -34,6 +38,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen : %v", err)
 	}
+
+	rabbitmq, err := messaging.NewRabbitMQ(rabbitmqUri)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rabbitmq.Close()
 
 	grcpServer := grpcserver.NewServer()
 

--- a/services/trip-service/internal/domain/trip.go
+++ b/services/trip-service/internal/domain/trip.go
@@ -18,6 +18,17 @@ type TripModel struct {
 	Driver   *pb.TripDriver
 }
 
+func (t *TripModel) ToProto() *pb.Trip {
+	return &pb.Trip{
+		Id:           t.ID.Hex(),
+		UserID:       t.UserId,
+		SelectedFare: t.RideFare.ToProto(),
+		Status:       t.Status,
+		Driver:       t.Driver,
+		Route:        t.RideFare.Route.ToProto(),
+	}
+}
+
 type TripRepository interface {
 	CreateTrip(ctx context.Context, trip *TripModel) (*TripModel, error)
 	SaveRideFare(ctx context.Context, fare *RideFareModel) error

--- a/services/trip-service/internal/infrastructure/events/trip_publisher.go
+++ b/services/trip-service/internal/infrastructure/events/trip_publisher.go
@@ -1,0 +1,20 @@
+package events
+
+import (
+	"context"
+	"ride-sharing/shared/messaging"
+)
+
+type TripEventPublisher struct {
+	rabbitmq *messaging.RabbitMQ
+}
+
+func NewTripEventPublisher(rabbitmq *messaging.RabbitMQ) *TripEventPublisher {
+	return &TripEventPublisher{
+		rabbitmq: rabbitmq,
+	}
+}
+
+func (p *TripEventPublisher) PublishTripCreated(ctx context.Context) error {
+	return p.rabbitmq.PublishMessage(ctx, "hello", "hello world")
+}

--- a/services/trip-service/internal/infrastructure/events/trip_publisher.go
+++ b/services/trip-service/internal/infrastructure/events/trip_publisher.go
@@ -2,6 +2,9 @@ package events
 
 import (
 	"context"
+	"encoding/json"
+	"ride-sharing/services/trip-service/internal/domain"
+	"ride-sharing/shared/contracts"
 	"ride-sharing/shared/messaging"
 )
 
@@ -15,6 +18,18 @@ func NewTripEventPublisher(rabbitmq *messaging.RabbitMQ) *TripEventPublisher {
 	}
 }
 
-func (p *TripEventPublisher) PublishTripCreated(ctx context.Context) error {
-	return p.rabbitmq.PublishMessage(ctx, "hello", "hello world")
+func (p *TripEventPublisher) PublishTripCreated(ctx context.Context, trip *domain.TripModel) error {
+	payload := messaging.TripEventData{
+		Trip: trip.ToProto(),
+	}
+
+	tripEventJSON, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	return p.rabbitmq.PublishMessage(ctx, contracts.TripEventCreated, contracts.AmqpMessage{
+		OwnerID: trip.UserId,
+		Data:    tripEventJSON,
+	})
 }

--- a/services/trip-service/internal/infrastructure/grpc/grpc_handler.go
+++ b/services/trip-service/internal/infrastructure/grpc/grpc_handler.go
@@ -43,7 +43,7 @@ func (h *grpcHandler) CreateTrip(ctx context.Context, r *pb.CreateTripRequest) (
 		return nil, status.Errorf(codes.Internal, "failed to create the trip: %v", err)
 	}
 
-	if err := h.publisher.PublishTripCreated(ctx); err != nil {
+	if err := h.publisher.PublishTripCreated(ctx, trip); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to publish the trip created event: %v", err)
 	}
 

--- a/services/trip-service/internal/infrastructure/grpc/grpc_handler.go
+++ b/services/trip-service/internal/infrastructure/grpc/grpc_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"ride-sharing/services/trip-service/internal/domain"
+	"ride-sharing/services/trip-service/internal/infrastructure/events"
 	pb "ride-sharing/shared/proto/trip"
 	"ride-sharing/shared/types"
 
@@ -14,12 +15,14 @@ import (
 
 type grpcHandler struct {
 	pb.UnimplementedTripServiceServer
-	service domain.TripService
+	service   domain.TripService
+	publisher *events.TripEventPublisher
 }
 
-func NewGrpcHandler(server *grpc.Server, service domain.TripService) *grpcHandler {
+func NewGrpcHandler(server *grpc.Server, service domain.TripService, publisher *events.TripEventPublisher) *grpcHandler {
 	handler := &grpcHandler{
-		service: service,
+		service:   service,
+		publisher: publisher,
 	}
 
 	pb.RegisterTripServiceServer(server, handler)
@@ -40,7 +43,9 @@ func (h *grpcHandler) CreateTrip(ctx context.Context, r *pb.CreateTripRequest) (
 		return nil, status.Errorf(codes.Internal, "failed to create the trip: %v", err)
 	}
 
-	// implement async communication with rabbitmq
+	if err := h.publisher.PublishTripCreated(ctx); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to publish the trip created event: %v", err)
+	}
 
 	return &pb.CreateTripResponse{
 		TripID: trip.ID.Hex(),

--- a/services/trip-service/internal/service/service.go
+++ b/services/trip-service/internal/service/service.go
@@ -138,19 +138,19 @@ func getBaseFares() []*domain.RideFareModel {
 	return []*domain.RideFareModel{
 		{
 			PackageSlug:       "sedan",
-			TotalPriceInCents: 200,
+			TotalPriceInCents: 100,
 		},
 		{
 			PackageSlug:       "suv",
-			TotalPriceInCents: 300,
+			TotalPriceInCents: 200,
 		},
 		{
 			PackageSlug:       "van",
-			TotalPriceInCents: 400,
+			TotalPriceInCents: 300,
 		},
 		{
 			PackageSlug:       "luxury",
-			TotalPriceInCents: 500,
+			TotalPriceInCents: 400,
 		},
 	}
 }

--- a/shared/messaging/events.go
+++ b/shared/messaging/events.go
@@ -1,0 +1,13 @@
+package messaging
+
+import (
+	pb "ride-sharing/shared/proto/trip"
+)
+
+const (
+	FindAvailableDriversQueue = "find_available_drivers"
+)
+
+type TripEventData struct {
+	Trip *pb.Trip `json:"trip"`
+}

--- a/shared/messaging/rabbitmq.go
+++ b/shared/messaging/rabbitmq.go
@@ -1,0 +1,30 @@
+package messaging
+
+import (
+	"fmt"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type RabbitMQ struct {
+	conn *amqp.Connection
+}
+
+func NewRabbitMQ(uri string) (*RabbitMQ, error) {
+	conn, err := amqp.Dial(uri)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to RabbitMQ: %v", err)
+	}
+
+	rmq := &RabbitMQ{
+		conn: conn,
+	}
+
+	return rmq, nil
+}
+
+func (r *RabbitMQ) Close() {
+	if r.conn != nil {
+		r.conn.Close()
+	}
+}

--- a/shared/messaging/rabbitmq.go
+++ b/shared/messaging/rabbitmq.go
@@ -45,15 +45,16 @@ func (r *RabbitMQ) PublishMessage(ctx context.Context, routingKey string, messag
 		false,   // mandatory
 		false,   // immediate
 		amqp.Publishing{
-			ContentType: "text/plain",
-			Body:        []byte(message),
+			ContentType:  "text/plain",
+			Body:         []byte(message),
+			DeliveryMode: amqp.Persistent,
 		})
 }
 
 func (r *RabbitMQ) setupExchangesAndQueues() error {
 	_, err := r.Channel.QueueDeclare(
 		"hello", // name
-		false,   // durable
+		true,    // durable
 		false,   // delete when unused
 		false,   // exclusive
 		false,   // no-wait

--- a/shared/messaging/rabbitmq.go
+++ b/shared/messaging/rabbitmq.go
@@ -66,7 +66,7 @@ func (r *RabbitMQ) ConsumeMessage(queueName string, handler MessageHandler) erro
 		nil,       // args
 	)
 	if err != nil {
-		return nil
+		return fmt.Errorf("failed to consume from queue %s: %v", queueName, err)
 	}
 
 	ctx := context.Background()
@@ -152,7 +152,7 @@ func (r *RabbitMQ) declareAndBindQueue(queueName string, messageTypes []string, 
 		nil,       // arguments
 	)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("failed to declare queue %s: %v", queueName, err)
 	}
 
 	for _, msg := range messageTypes {

--- a/shared/messaging/rabbitmq.go
+++ b/shared/messaging/rabbitmq.go
@@ -2,10 +2,16 @@ package messaging
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"ride-sharing/shared/contracts"
 
 	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+const (
+	TripExchange = "trip"
 )
 
 type RabbitMQ struct {
@@ -88,31 +94,79 @@ func (r *RabbitMQ) ConsumeMessage(queueName string, handler MessageHandler) erro
 	return nil
 }
 
-func (r *RabbitMQ) PublishMessage(ctx context.Context, routingKey string, message string) error {
+func (r *RabbitMQ) PublishMessage(ctx context.Context, routingKey string, message contracts.AmqpMessage) error {
+	log.Printf("Publishing message with routing key: %s", routingKey)
+
+	jsonMsg, err := json.Marshal(message)
+	if err != nil {
+		return fmt.Errorf("failed to marshal message: %v", err)
+	}
+
 	return r.Channel.PublishWithContext(ctx,
-		"",      // exchange
-		"hello", // routing key
-		false,   // mandatory
-		false,   // immediate
+		TripExchange, // exchange
+		routingKey,   // routing key
+		false,        // mandatory
+		false,        // immediate
 		amqp.Publishing{
 			ContentType:  "text/plain",
-			Body:         []byte(message),
+			Body:         []byte(jsonMsg),
 			DeliveryMode: amqp.Persistent,
 		})
 }
 
 func (r *RabbitMQ) setupExchangesAndQueues() error {
-	_, err := r.Channel.QueueDeclare(
-		"hello", // name
-		true,    // durable
-		false,   // delete when unused
-		false,   // exclusive
-		false,   // no-wait
-		nil,     // arguments
+	err := r.Channel.ExchangeDeclare(
+		TripExchange, // name
+		"topic",      // type
+		true,         // durable
+		false,        // auto-deleted
+		false,        // internal
+		false,        // no-wait
+		nil,          // arguments
+	)
+	if err != nil {
+		return fmt.Errorf("failed to declare exchange %s: %v", TripExchange, err)
+	}
+
+	if err := r.declareAndBindQueue(
+		FindAvailableDriversQueue,
+		[]string{
+			contracts.TripEventCreated,
+			contracts.TripEventDriverNotInterested,
+		},
+		TripExchange,
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *RabbitMQ) declareAndBindQueue(queueName string, messageTypes []string, exchange string) error {
+	q, err := r.Channel.QueueDeclare(
+		queueName, // name
+		true,      // durable
+		false,     // delete when unused
+		false,     // exclusive
+		false,     // no-wait
+		nil,       // arguments
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	for _, msg := range messageTypes {
+		if err := r.Channel.QueueBind(
+			q.Name,   // queue name
+			msg,      // routing key
+			exchange, // exchange
+			false,
+			nil,
+		); err != nil {
+			return fmt.Errorf("failed to bind queue to %s: %v", queueName, err)
+		}
+	}
+
 	return nil
 }
 

--- a/shared/messaging/rabbitmq.go
+++ b/shared/messaging/rabbitmq.go
@@ -38,6 +38,56 @@ func NewRabbitMQ(uri string) (*RabbitMQ, error) {
 	return rmq, nil
 }
 
+type MessageHandler func(context.Context, amqp.Delivery) error
+
+func (r *RabbitMQ) ConsumeMessage(queueName string, handler MessageHandler) error {
+	err := r.Channel.Qos(
+		1,     // prefetch count
+		0,     // prefetch size
+		false, // global
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set QoS: %v", err)
+	}
+
+	msgs, err := r.Channel.Consume(
+		queueName, // queue
+		"",        // consumer
+		false,     // auto-ack
+		false,     // exclusive
+		false,     // no-local
+		false,     // no-wait
+		nil,       // args
+	)
+	if err != nil {
+		return nil
+	}
+
+	ctx := context.Background()
+
+	go func() {
+		for msg := range msgs {
+			log.Printf("Received a message: %s", msg.Body)
+
+			if err := handler(ctx, msg); err != nil {
+				log.Printf("ERROR: Failed to handle message: %v. Message body: %s", err, msg.Body)
+
+				if nackErr := msg.Nack(false, false); nackErr != nil {
+					log.Printf("ERROR: Failed to Nack message: %v", nackErr)
+				}
+
+				continue
+			}
+
+			if ackErr := msg.Ack(false); ackErr != nil {
+				log.Printf("ERROR: Failed to ack message: %v. Message body: %s", ackErr, msg.Body)
+			}
+		}
+	}()
+
+	return nil
+}
+
 func (r *RabbitMQ) PublishMessage(ctx context.Context, routingKey string, message string) error {
 	return r.Channel.PublishWithContext(ctx,
 		"",      // exchange

--- a/shared/messaging/rabbitmq.go
+++ b/shared/messaging/rabbitmq.go
@@ -1,13 +1,16 @@
 package messaging
 
 import (
+	"context"
 	"fmt"
+	"log"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 type RabbitMQ struct {
-	conn *amqp.Connection
+	conn    *amqp.Connection
+	Channel *amqp.Channel
 }
 
 func NewRabbitMQ(uri string) (*RabbitMQ, error) {
@@ -16,15 +19,57 @@ func NewRabbitMQ(uri string) (*RabbitMQ, error) {
 		return nil, fmt.Errorf("failed to connect to RabbitMQ: %v", err)
 	}
 
+	ch, err := conn.Channel()
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to create channel: %v", err)
+	}
+
 	rmq := &RabbitMQ{
-		conn: conn,
+		conn:    conn,
+		Channel: ch,
+	}
+
+	if err := rmq.setupExchangesAndQueues(); err != nil {
+		rmq.Close()
+		return nil, fmt.Errorf("failed to setup exchanges and queues: %v", err)
 	}
 
 	return rmq, nil
 }
 
+func (r *RabbitMQ) PublishMessage(ctx context.Context, routingKey string, message string) error {
+	return r.Channel.PublishWithContext(ctx,
+		"",      // exchange
+		"hello", // routing key
+		false,   // mandatory
+		false,   // immediate
+		amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        []byte(message),
+		})
+}
+
+func (r *RabbitMQ) setupExchangesAndQueues() error {
+	_, err := r.Channel.QueueDeclare(
+		"hello", // name
+		false,   // durable
+		false,   // delete when unused
+		false,   // exclusive
+		false,   // no-wait
+		nil,     // arguments
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return nil
+}
+
 func (r *RabbitMQ) Close() {
 	if r.conn != nil {
 		r.conn.Close()
+	}
+	if r.Channel != nil {
+		r.Channel.Close()
 	}
 }


### PR DESCRIPTION
This pull request introduces RabbitMQ-based asynchronous communication between the trip and driver services, enabling event-driven driver selection for trips. It adds Kubernetes manifests and configuration for RabbitMQ, updates service deployments to use RabbitMQ, and implements the required messaging logic in both services. Additionally, it refines trip fare pricing and improves error handling.

**Messaging and Event-Driven Architecture**

* Added a new RabbitMQ deployment manifest (`infra/development/k8s/rabbitmq-deployment.yaml`) and configured Tilt to deploy RabbitMQ and expose its ports for local development. [[1]](diffhunk://#diff-0106ea2a255b5b882b8f426fee5e4a0c92a8afbb2782a41ae5e1b9b989826f93R1-R82) [[2]](diffhunk://#diff-c2ee8653e1d6b85f0aadf87cd438a9250806c052877248442be4d434cbc52425L6-R15)
* Integrated RabbitMQ into both the trip and driver services, including environment variable configuration and service dependencies in Tilt. Services now connect to RabbitMQ using credentials from Kubernetes secrets. [[1]](diffhunk://#diff-c2ee8653e1d6b85f0aadf87cd438a9250806c052877248442be4d434cbc52425L41-R45) [[2]](diffhunk://#diff-c2ee8653e1d6b85f0aadf87cd438a9250806c052877248442be4d434cbc52425L71-R75) [[3]](diffhunk://#diff-c2ee8653e1d6b85f0aadf87cd438a9250806c052877248442be4d434cbc52425L101-R105) [[4]](diffhunk://#diff-9754d4756636f656f2126a4d51f6ded667fbcf8baf053b89a6ed034632391c5fR27-R33) [[5]](diffhunk://#diff-bbc8d7eabb16be8e9dd321bf5f932d8e52ee054e5d86c6d1b79220a1919a218dR27-R32) [[6]](diffhunk://#diff-d74f4e8de86f89ef5896b6d956a0748d0b9526e3eedb7525002892055599bc0eR19-R20) [[7]](diffhunk://#diff-ce960f73f862c3dd712b707e7acfca743e829a2a8fb72f5e674e0713dd3ba73fR23-R24) [[8]](diffhunk://#diff-35e68cbd32f44752019b8b3fe7409ea8d20b3bd06809e969782932b83f64d094R1-R180)
* Implemented a messaging layer (`shared/messaging/rabbitmq.go`, `shared/messaging/events.go`) that handles publishing and consuming messages, queue setup, and exchange declaration for trip-related events. [[1]](diffhunk://#diff-35e68cbd32f44752019b8b3fe7409ea8d20b3bd06809e969782932b83f64d094R1-R180) [[2]](diffhunk://#diff-c7a2fb22af0537b93799ffd4cb219f33d824e811514d2caef00e948e987fb225R1-R13)

**Trip Service Enhancements**

* Trip service now publishes a "trip created" event to RabbitMQ when a new trip is created, using the new `TripEventPublisher` class. The gRPC handler was updated to accept a publisher and invoke it after trip creation. [[1]](diffhunk://#diff-45f5321c111776fc435c2aead26359d4c0801c1797a0f98621ef544f6bffd003R1-R35) [[2]](diffhunk://#diff-80e085cffd2268eed02f3a5af9cbf28b634061c5dfa1ff0f2c89a870fd65d9b2R7) [[3]](diffhunk://#diff-80e085cffd2268eed02f3a5af9cbf28b634061c5dfa1ff0f2c89a870fd65d9b2R19-R25) [[4]](diffhunk://#diff-80e085cffd2268eed02f3a5af9cbf28b634061c5dfa1ff0f2c89a870fd65d9b2L43-R48) [[5]](diffhunk://#diff-ce960f73f862c3dd712b707e7acfca743e829a2a8fb72f5e674e0713dd3ba73fR43-R53) [[6]](diffhunk://#diff-f39b0828f0daf8c94bbb815e37ea18a4f49c18f1d22cc8c01a8fc2ac7a92e746R21-R31)
* Base fares for trip packages were adjusted to lower values for sedan, suv, van, and luxury.

**Driver Service Enhancements**

* Driver service now consumes trip events from RabbitMQ. When a trip is created or a driver is not interested, the service selects suitable drivers and publishes a response event. This logic is implemented in the new `trip_consumer.go` and uses the new `FindAvailableDrivers` method. [[1]](diffhunk://#diff-34591908019be4e12b05c93117a9b3c6e994c58f678ff2b20e709537f1e713a2R1-R78) [[2]](diffhunk://#diff-a218930105bdaa06b1fec7080c376d18b1ba3d322f8de23da3e6ce01195e38c3R27-R42) [[3]](diffhunk://#diff-d74f4e8de86f89ef5896b6d956a0748d0b9526e3eedb7525002892055599bc0eR38-R53)
* The driver service deployment is scaled to two replicas for improved availability.

**General Improvements**

* Improved error messages for trip creation in the API gateway to better reflect the operation being performed.