### PR TITLE
feat: implement dead letter exchange and queue for RabbitMQ

### DIFF
--- a/shared/messaging/events.go
+++ b/shared/messaging/events.go
@@ -13,6 +13,7 @@ const (
 	NotifyDriverAssignQueue          = "notify_driver_assign"
 	PaymentTripResponseQueue         = "payment_trip_response"
 	NotifyPaymentSessionCreatedQueue = "notify_payment_session_created"
+	DeadLetterQueue                  = "dead_letter_queue"
 )
 
 type TripEventData struct {

--- a/shared/messaging/rabbitmq.go
+++ b/shared/messaging/rabbitmq.go
@@ -6,13 +6,15 @@ import (
 	"fmt"
 	"log"
 	"ride-sharing/shared/contracts"
+	"ride-sharing/shared/retry"
 	"ride-sharing/shared/tracing"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 const (
-	TripExchange = "trip"
+	TripExchange        = "trip"
+	DeadeLetterExchange = "dlx"
 )
 
 type RabbitMQ struct {
@@ -75,13 +77,25 @@ func (r *RabbitMQ) ConsumeMessage(queueName string, handler MessageHandler) erro
 			if err := tracing.TracedConsumer(msg, func(ctx context.Context, d amqp.Delivery) error {
 				log.Printf("Received a message: %s", msg.Body)
 
-				if err := handler(ctx, msg); err != nil {
-					log.Printf("ERROR: Failed to handle message: %v. Message body: %s", err, msg.Body)
+				config := retry.DefaultConfig()
+				err := retry.WithBackoff(ctx, config, func() error {
+					return handler(ctx, d)
+				})
+				if err != nil {
+					log.Printf("Message processing failed after %d retries for message ID: %s, err: %v", config.MaxRetries, d.MessageId, err)
 
-					if nackErr := msg.Nack(false, false); nackErr != nil {
-						log.Printf("ERROR: Failed to Nack message: %v", nackErr)
+					headers := amqp.Table{}
+					if d.Headers != nil {
+						headers = d.Headers
 					}
 
+					headers["x-death-reason"] = err.Error()
+					headers["x-origin-exchange"] = d.Exchange
+					headers["x-original-routing-key"] = d.RoutingKey
+					headers["x-retry-count"] = config.MaxRetries
+					d.Headers = headers
+
+					_ = d.Reject(false)
 					return err
 				}
 
@@ -126,7 +140,50 @@ func (r *RabbitMQ) publish(ctx context.Context, exchange, routingKey string, msg
 	)
 }
 
+func (r *RabbitMQ) setupDeadLetterExchange() error {
+	err := r.Channel.ExchangeDeclare(
+		DeadeLetterExchange, // name
+		"topic",             // type
+		true,                // durable
+		false,               // auto-deleted
+		false,               // internal
+		false,               // no-wait
+		nil,                 // arguments
+	)
+	if err != nil {
+		return fmt.Errorf("failed to declare exchange dead letter exchange: %v", err)
+	}
+
+	q, err := r.Channel.QueueDeclare(
+		DeadLetterQueue, // name
+		true,            // durable
+		false,           // delete when unused
+		false,           // exclusive
+		false,           // no-wait
+		nil,             // arguments
+	)
+	if err != nil {
+		return fmt.Errorf("failed to declare dead letter queue: %v", err)
+	}
+
+	if err := r.Channel.QueueBind(
+		q.Name,              // queue name
+		"#",                 // routing key
+		DeadeLetterExchange, // exchange
+		false,
+		nil,
+	); err != nil {
+		return fmt.Errorf("failed to bind dead letter queue: %v", err)
+	}
+
+	return nil
+}
+
 func (r *RabbitMQ) setupExchangesAndQueues() error {
+	if err := r.setupDeadLetterExchange(); err != nil {
+		return err
+	}
+
 	err := r.Channel.ExchangeDeclare(
 		TripExchange, // name
 		"topic",      // type
@@ -216,13 +273,17 @@ func (r *RabbitMQ) setupExchangesAndQueues() error {
 }
 
 func (r *RabbitMQ) declareAndBindQueue(queueName string, messageTypes []string, exchange string) error {
+	args := amqp.Table{
+		"x-dead-letter-exchange": DeadeLetterExchange,
+	}
+
 	q, err := r.Channel.QueueDeclare(
 		queueName, // name
 		true,      // durable
 		false,     // delete when unused
 		false,     // exclusive
 		false,     // no-wait
-		nil,       // arguments
+		args,      // arguments
 	)
 	if err != nil {
 		return fmt.Errorf("failed to declare queue %s: %v", queueName, err)


### PR DESCRIPTION
This pull request introduces a robust dead-letter queue (DLQ) mechanism to the messaging infrastructure, enhancing message reliability and traceability when processing failures occur. The main changes include the creation and configuration of a dead-letter exchange and queue, integration of retry logic with backoff for message handling, and the propagation of failure metadata for easier debugging.

**Dead-letter queue integration:**

* Added a new constant `DeadLetterQueue` to `events.go` to represent the DLQ name.
* Declared and bound a new dead-letter exchange (`DeadeLetterExchange`) and queue in `rabbitmq.go`, ensuring all message queues now forward failed messages to the DLQ. [[1]](diffhunk://#diff-35e68cbd32f44752019b8b3fe7409ea8d20b3bd06809e969782932b83f64d094R9-R17) [[2]](diffhunk://#diff-35e68cbd32f44752019b8b3fe7409ea8d20b3bd06809e969782932b83f64d094R143-R186) [[3]](diffhunk://#diff-35e68cbd32f44752019b8b3fe7409ea8d20b3bd06809e969782932b83f64d094R276-R286)

**Message handling and retry logic:**

* Updated the `ConsumeMessage` method to use a retry mechanism with backoff from the new `retry` package. If message processing fails after all retries, the message is rejected and routed to the DLQ.

**Failure metadata propagation:**

* When a message is rejected after retries, additional metadata is attached to the message headers (reason, original exchange, routing key, retry count) to aid in debugging and traceability.